### PR TITLE
Issue-264: Very basic pkgbuild wrapper

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -98,6 +98,50 @@ Here, the Debian package is built from three `pkg_tar` targets:
 `debian-data` is then used for the data content of the debian archive created by
 `pkg_deb`.
 
+<a name="basic-example"></a>
+### MacOS Example
+
+This example shows the difference to build a MacOS Flat-Package PKG of Bazel:
+
+```python
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:pkgbuild.bzl", "pkgbuild_tars")
+
+pkg_tar(
+    name = "bazel-bin",
+    strip_prefix = "/src",
+    package_dir = "/usr/local/bin",
+    srcs = ["//src:bazel"],
+    mode = "0755",
+)
+
+pkg_tar(
+    name = "bazel-tools",
+    strip_prefix = "/",
+    package_dir = "/usr/local/share/lib/bazel/tools",
+    srcs = ["//tools:package-srcs"],
+    mode = "0644",
+)
+
+# The resulting PKG should be installable by:
+#
+# sudo installer -pkg bazel.pkg -target /
+pkgbuild_tars(
+    name = "bazel",
+    tars = [ ":bazel-bin", ":bazel-tools" ],
+    package_name = "bazel",
+    version = "0.1.1",
+)
+```
+
+Here, the MacOS package is built from two `pkg_tar` targets:
+
+ - `bazel-bin` creates a tarball with the main binary (mode `0755`) in
+   `/usr/local/bin`,
+ - `bazel-tools` create a tarball with the base workspace (mode `0644`) to
+   `/usr/local/share/bazel/tools` ; the `modes` attribute let us specifies executable
+   files,
+
 <a name="roadmap"></a>
 ## Roadmap
 

--- a/pkg/pkgbuild.bzl
+++ b/pkg/pkgbuild.bzl
@@ -1,0 +1,18 @@
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rules for manipulation of various packaging."""
+
+load("//pkg/private/pkgbuild:pkgbuild.bzl", _pkgbuild_tars = "pkgbuild_tars")
+
+pkgbuild_tars = _pkgbuild_tars

--- a/pkg/private/pkgbuild/BUILD
+++ b/pkg/private/pkgbuild/BUILD
@@ -1,0 +1,44 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""rules_pkg internal code.
+
+All interfaces are subject to change at any time.
+"""
+
+package(default_applicable_licenses = ["//:license"])
+
+filegroup(
+    name = "standard_package",
+    srcs = [
+        "BUILD",
+    ] + glob([
+        "*.bzl",
+    ]),
+    visibility = ["//distro:__pkg__"],
+)
+
+exports_files(
+    glob([
+        "*.bzl",
+    ]),
+    visibility = [
+        "//distro:__pkg__",
+        "//doc_build:__pkg__",
+    ],
+)
+
+exports_files(
+    ["pkgbuild_tars.sh.tpl"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/private/pkgbuild/pkgbuild.bzl
+++ b/pkg/private/pkgbuild/pkgbuild.bzl
@@ -1,0 +1,118 @@
+#
+# MacOS Packaging logic
+#
+# This is intended as the first step in comprehensive package build on MacOS.  It replaces the
+# following style of command:
+#
+#     pkgbuild \
+#         --identifier (domain).$(PKG_NAME) \
+#         --component-plist $(PLIST) \
+#         --scripts $(SCRIPTS) \
+#         --version $(VER_BAZELISK) \
+#         --root $(STAGE)  \
+#     $(DESTDIR)/$(PKG_UPPERNAME)-$(VER_BAZELISK).pkg:
+#
+# Identifiers refs:
+#   - https://en.wikipedia.org/wiki/Uniform_Type_Identifier
+#   - https://en.wikipedia.org/wiki/Reverse_domain_name_notation
+#
+# As with the command it replaces, this isintended to be installable in a simple CLI such as:
+#
+#     sudo installer -pkg bazel-out/darwin-fastbuild/bin/chickenandbazel.pkg -target /
+
+def _pkgbuild_tars_impl(ctx):
+    """Completes a "pkgbuild --root" but pre-deployed the "tars" to that given "root".
+    Args:
+        name: A unique name for this rule.
+        component_plist: location of a plist file.
+        identifier: an Apple UTI -- ie Reverse-DNS Notation name for the package: Defaults to
+            com.example.{name} but watch for the expected namespace/name clash this default
+            can cause.
+        package_name: (optional) Target package name, defaulting to (name).pkg.
+        tars: One or more tar archives representing deliverables that should be extracted in "root"
+            before packaging.
+        version: a version string for the package; recommending Semver for simplicity.  Comparing
+            two versions of matching identifier can be used to determine whether one package
+            upgrades or downgrades another.
+    """
+
+    component_plist_opt = ""
+    if ctx.attr.component_plist:
+        component_plist_opt = "--component-plist \"{}\"".format(ctx.file.component_plist)
+
+    identifier = ctx.attr.identifier or "com.example.{}".format(ctx.attr.name)
+    package_name = ctx.attr.package_name or "{}.pkg".format(ctx.attr.name)
+    pkg = ctx.actions.declare_file(package_name)
+    inputs = [] + ctx.files.tars # TODO: plus pkgbuild, plus template, plus plist
+
+    #pkgbuild_toolchain = ctx.toolchains["@rules_pkg//toolchains/macos:pkgbuild_toolchain_type"].pkgbuild.path
+
+    # Generate a script from hydrating a template so that we can review the script to diagnose/debug
+    script_file = ctx.actions.declare_file("{}_pkgbuild".format(ctx.label.name))
+    ctx.actions.expand_template(
+        template = ctx.file._script_template,
+        output = script_file,
+        is_executable = True,
+        substitutions = {
+            "{IDENTIFIER}": identifier,
+            "{OPT_COMPONENT_PLIST}": component_plist_opt,
+            "{OPT_SCRIPTS_DIR}": "",
+            "{OUTPUT}": pkg.path,
+            #"{PKGBUILD}": pkgbuild_toolchain,
+            "{TARS}": " ".join([ f.path for f in ctx.files.tars ]),
+            "{VERSION}": ctx.attr.version,
+        },
+    )
+
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = [pkg],
+        arguments = [],
+        executable = script_file,
+        execution_requirements = {
+            "local": "1",
+            "no-remote": "1",
+            "no-remote-exec": "1",
+        },
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([pkg]),
+        ),
+    ]
+
+pkgbuild_tars = rule(
+    implementation = _pkgbuild_tars_impl,
+    attrs = {
+        "tars": attr.label_list(
+            #allow_files = True,
+            mandatory = True,
+            doc = "One or more tar archives that should be extracted in 'root' before packaging",
+        ),
+        "package_name": attr.string(
+            mandatory = False,
+            doc = "resulting filename.pkg, defaults to (name).pkg, analogous to the 'package-output-path'",
+        ),
+        "identifier": attr.string(
+            mandatory = False,
+            doc = "An Apple Uniform Type Identifier (similar to a Reverse-DNS Notation) as a unique identifier for this package"
+        ),
+        "component_plist": attr.label(allow_files = True, mandatory = False),
+        "version": attr.string(
+            mandatory = True,
+            default = "0",
+            doc = "A version for the package; used to compare against different versions of the 'identifier' to see whether this upgrades or downgrades an existing install",
+        ),
+        "_script_template": attr.label(
+            allow_single_file = True,
+            default = ":pkgbuild_tars.sh.tpl",
+        ),
+    },
+    doc = "Package a complete destination root.  For example, the 'xcodebuild' tool with the 'install' action creates a destination root.  This rule is intended to package up a destination root that would be given as 'pkgbuild --root' except that it wants to lay out the given 'tars' into that 'root' before packaging",
+)
+
+# NOTES
+#
+# full paths?  https://github.com/bazelbuild/rules_python/blob/main/python/defs.bzl#L76
+

--- a/pkg/private/pkgbuild/pkgbuild_tars.sh.tpl
+++ b/pkg/private/pkgbuild/pkgbuild_tars.sh.tpl
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# pkgbuild_tars.sh is intended to create a flat-package -style pkg by extracting a number of
+# tarchives to a "root" area, then packaging that up with a "pkgbuild --root ..." command.  This
+# isn't overly complex, but can be convenient.
+#
+# This process does not build nor merge code into multi-arch binaries; you'll need to do that
+# before putting them into the listed tars.  Additionally, I haven't addressed code-signing, but I
+# gather the individual binaries should be signed before adding into tarchives.
+#
+# It is anticipated that non "-root" packaging will be done, so I've named this one
+# "pkgbuild_tars.sh" to allow the non-tars-based packaging to be easily identified as well.
+
+TMPDIR=`mktemp -d -t pkgbuild` || { echo "$0: Cannot create working (root) directory; aborting"; exit 1; }
+
+# extract all tarchives to the designated root
+for t in {TARS} ; do
+	tar -C "${TMPDIR}" -xf ${t}
+done
+
+# really should have pkgbuild coming in as a toolchain from the installed Xcode
+
+/usr/bin/pkgbuild \
+    --identifier "{IDENTIFIER}" \
+    {OPT_COMPONENT_PLIST} \
+    {OPT_SCRIPTS_DIR} \
+    --version "{VERSION}" \
+    --root "${TMPDIR}" \
+    "{OUTPUT}"
+


### PR DESCRIPTION
Provide a basic packaging of `pkg_tar` archives into MacOS flat-pack packages.

In order to address https://github.com/bazelbuild/rules_pkg/issues/264 this creates a basic flat-package format PKG of the content in the tars.  This allows use of tar archives with `package_dir` set to `/Applications/AppName.pkg/` to unpack to the Applications dir, or a simple `/usr/local/bin` for less-complicated scripts and CLI tools.

```python
load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
load("@rules_pkg//pkg:pkgbuild.bzl", "pkgbuild_tars")

pkg_tar(
    name = "bazel-bin",
    strip_prefix = "/src",
    package_dir = "/usr/local/bin",
    srcs = ["//src:bazel"],
    mode = "0755",
)

pkg_tar(
    name = "bazel-tools",
    strip_prefix = "/",
    package_dir = "/usr/local/share/lib/bazel/tools",
    srcs = ["//tools:package-srcs"],
    mode = "0644",
)

# The resulting PKG should be installable by:
#
# sudo installer -pkg bazel.pkg -target /
pkgbuild_tars(
    name = "bazel",
    tars = [ ":bazel-bin", ":bazel-tools" ],
    package_name = "bazel",
    version = "0.1.1",
)
```




